### PR TITLE
Make the local project explicit for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,6 @@
 name = "mymath"
 version = "1.0.0"
 requires-python = '>=3.10'
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
A common practice is to configure pytest to recognize your package. You can do this in your pyproject.toml file or a pytest.ini file. Adding pythonpath = ["."] tells pytest to include the current directory (the project root) in the Python search path. This allows it to find the mymath package during the test run.